### PR TITLE
chore: use the correct name for Enid

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Eludris</title>
+        <title>Enid</title>
         <link rel="stylesheet" href="" />
         <link rel="manifest" href="manifest.webmanifest" />
         <meta
@@ -13,7 +13,7 @@
         <link rel="icon" type="image/svg+xml" href="assets/enid.svg" />
 
         <meta name="twitter:card" content="summary" />
-        <meta property="og:title" content="Eludris" />
+        <meta property="og:title" content="Enid" />
         <meta
             property="og:description"
             content="Your secure and private social network"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "short_name": "enid",
-    "name": "Eludris: Secure chatting",
+    "name": "Enid: Secure chatting",
     "id": "com.teaishealthy.enid",
     "start_url": "/index.html",
     "background_color": "#3367D6",


### PR DESCRIPTION
## Why?

Simply put, Enid - much like a lot of other community stuff (including my own eludrs) - is not an official Eludris product.
This is an issue here because Enid is a client for Eludris and Eludris *does* already have an official client (pengin). 

Now, in cases like API wrappers, where Eludris will probably never make an official API wrapper, or where most users know it isn't official, this is not an issue. However in this case what you're more-or-less doing is impersonating the official client which will prove quite problematic for Eludris in the future.

## Why Does Official Stuff Exist?

To answer that it'd first make sense to properly explain what an official thing is. Basically when Eludris says that `x` is official, this means that it is made, maintained and kept track off by Eludris. In other words, when and if something goes wrong with it - or if it has issues (which both you and I pointed Enid had some of (which after agreeing you proceeded to ignore my feedback)) Eludris will be the one held liable for it.

Eludris will keep maintaining it's official stuff until it is either done or deleted. This means that any issues with Eludris will get properly reviewed by the Eludris team and promptly dealt with.

A 3rd party thing acting like it's official (which in the case of a client is really easy) is a major issue for that cause. Simply put, if you do something stupid or make a sub-par client we'll be held liable.

Now, I do currently not have any legal grounds to force you to stop using an official name in front of users when you already have your own, however refusing to merge this PR request will be seen as an act of hostility and I will take action against it by limiting your rights to the community org until you take back your repos then leave. It doesn't take a genius to figure out that this PR makes sense either and I've made it as easy as pressing the big green button, not merging after all of that would be quite un-poggers IMO :D